### PR TITLE
feat: add brew installer helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [0.3.1.0] – 2025-05-31
+
+### 🆕 Added
+* `install_brew_tool` helper in `scripts/lib.sh` for Homebrew installs
+
+### ✅ Status
+* Library functions expanded; no behavior change yet
+
+---
+
 ## [0.3.0.0] – 2025-05-30
 
 ### 🆕 Added

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -33,6 +33,41 @@ install_tool() {
   fi
 }
 
+# Homebrew installer helper
+install_brew_tool() {
+  local tool="$1"
+  local log_enabled="${LOGGING:-true}"
+
+  if [[ "$log_enabled" == "true" ]]; then
+    echo "Processing $tool..." | tee -a "$LOG_DIR/setup.log"
+  else
+    echo "Processing $tool..."
+  fi
+
+  if ! command -v brew >/dev/null 2>&1; then
+    if [[ "$log_enabled" == "true" ]]; then
+      echo "Warning: brew not found. Cannot install $tool" | tee -a "$LOG_DIR/setup.log"
+    else
+      echo "Warning: brew not found. Cannot install $tool"
+    fi
+    return 1
+  fi
+
+  if [[ "${DRY_RUN:-false}" == "true" ]]; then
+    if [[ "$log_enabled" == "true" ]]; then
+      echo "[dry-run] Would run: brew install $tool" | tee -a "$LOG_DIR/setup.log"
+    else
+      echo "[dry-run] Would run: brew install $tool"
+    fi
+  else
+    if [[ "$log_enabled" == "true" ]]; then
+      brew install "$tool" 2>>"$LOG_DIR/error.log" | tee -a "$LOG_DIR/setup.log"
+    else
+      brew install "$tool"
+    fi
+  fi
+}
+
 # Run the per-phase iteration loop
 run_phase_loop() {
   # Validate YAML syntax


### PR DESCRIPTION
## Summary
- implement `install_brew_tool` function in `lib.sh`
- document new helper in the changelog

## Testing
- `bash tests/linux/smoke-bootstrap.sh`
- `bash tests/macos/smoke-engine-dev-env.sh` *(fails: yq not installed)*
- `pwsh tests/windows/smoke-bootstrap.ps1` *(fails: pwsh missing)*

------
https://chatgpt.com/codex/tasks/task_e_68621f59943c832ea3b5f64394d283a9