### PR TITLE
feat(dotfiles): integrate chezmoi-managed dotfiles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,10 @@ scripts/
   setup-windows.ps1           # Windows engine (PowerShell)
 configs/
   dev-env.yml                 # Declarative tool list (name, manager, manual, platform)
-  .zshrc  .bashrc  .aliases   # Shell templates (chezmoi-ready later)
-  .gitconfig  settings.json   # App/editor templates
+dotfiles/                     # Chezmoi-managed home files
+  dot_zshrc  dot_gitconfig    # Shell and Git templates
+  aliases.sh aliases.ps1      # Shared alias definitions
+  dot_config/Code/User/settings.json # VS Code settings
 tests/
   macos/
     smoke-bootstrap.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [0.3.1.0] – 2025-06-02
+
+### 🆕 Added
+* `dotfiles/` directory managed by `chezmoi`
+* `bootstrap` applies dotfiles via `chezmoi`
+
+### 🧪 Tests
+* Smoke tests verify `chezmoi` dry-run output
+
+---
+
 ## [0.3.0.0] – 2025-05-30
 
 ### 🆕 Added

--- a/README.md
+++ b/README.md
@@ -63,10 +63,13 @@ Set-ExecutionPolicy Bypass -Scope Process
 │   ├── setup.ps1             # Windows installer
 │   ├── test-setup.sh         # Validation script
 ├── 📂 configs/
-│   ├── .bashrc
-│   ├── .zshrc
-│   ├── .gitconfig
-│   ├── vscode-settings.json
+│   └── dev-env.yml           # Tool declarations
+├── 📂 dotfiles/
+│   ├── dot_zshrc             # zsh config (chezmoi)
+│   ├── dot_gitconfig         # Git config (chezmoi)
+│   ├── aliases.sh            # Shared shell aliases
+│   ├── aliases.ps1           # PowerShell aliases
+│   └── dot_config/Code/User/settings.json # VS Code settings
 ├── 📂 packages/
 │   ├── Brewfile              # macOS/Linux packages
 │   ├── choco-install.ps1     # Windows packages

--- a/bootstrap
+++ b/bootstrap
@@ -5,6 +5,11 @@ set -euo pipefail
 # determine where this script lives
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
+DRY_RUN=false
+for arg in "$@"; do
+  [[ $arg == --dry-run ]] && DRY_RUN=true
+done
+
 if [ -n "${BASH_VERSION:-}" ]; then
   # Unix branch: dispatch based on OS
   case "$(uname -s)" in
@@ -19,6 +24,21 @@ if [ -n "${BASH_VERSION:-}" ]; then
       exit 1
       ;;
   esac
+
+  CHEZMOI_SOURCE="$SCRIPT_DIR/dotfiles"
+  if command -v chezmoi >/dev/null 2>&1; then
+    if [ "$DRY_RUN" = true ]; then
+      echo "🧪 [dry-run] applying dotfiles with chezmoi"
+      chezmoi init --source="$CHEZMOI_SOURCE" >/dev/null 2>&1 || true
+      chezmoi apply --source="$CHEZMOI_SOURCE" --dry-run
+    else
+      echo "📁 Applying dotfiles with chezmoi"
+      chezmoi init --source="$CHEZMOI_SOURCE" >/dev/null 2>&1 || true
+      chezmoi apply --source="$CHEZMOI_SOURCE"
+    fi
+  else
+    echo "⚠️ chezmoi not found; skipping dotfiles"
+  fi
   exit 0
 fi
 

--- a/docs/modules/aliases.md
+++ b/docs/modules/aliases.md
@@ -10,8 +10,8 @@ Define and install a consistent set of cross-platform command-line aliases to ac
 
 | Shell      | File Injected To        | Managed By            |
 | ---------- | ----------------------- | --------------------- |
-| zsh/bash   | `~/.zshrc`, `~/.bashrc` | `configs/aliases.sh`  |
-| PowerShell | `$PROFILE`              | `configs/aliases.ps1` |
+| zsh/bash   | `~/.zshrc`, `~/.bashrc` | `dotfiles/aliases.sh`  |
+| PowerShell | `$PROFILE`              | `dotfiles/aliases.ps1` |
 
 ---
 
@@ -19,8 +19,8 @@ Define and install a consistent set of cross-platform command-line aliases to ac
 
 Aliases are stored in:
 
-* `configs/aliases.sh` (for bash/zsh)
-* `configs/aliases.ps1` (for PowerShell)
+* `dotfiles/aliases.sh` (for bash/zsh)
+* `dotfiles/aliases.ps1` (for PowerShell)
 
 **Typical entries include:**
 

--- a/docs/modules/dotfiles.md
+++ b/docs/modules/dotfiles.md
@@ -8,9 +8,9 @@ Install and manage custom configuration files for shells, git, editors, and othe
 
 ## 📦 Install Method
 
-| OS  | Method          | Source               |
-| --- | --------------- | -------------------- |
-| All | Symlink or copy | `configs/` directory |
+| OS  | Method          | Source      |
+| --- | ---------------- | ----------- |
+| All | `chezmoi apply` | `dotfiles/` |
 
 ---
 
@@ -18,13 +18,11 @@ Install and manage custom configuration files for shells, git, editors, and othe
 
 | Dotfile            | Target Path           | Source File                    | Notes                           |
 | ------------------ | --------------------- | ------------------------------ | ------------------------------- |
-| `.zshrc`           | `~/.zshrc`            | `configs/.zshrc`               | Used by zsh login shell         |
-| `.bashrc`          | `~/.bashrc`           | `configs/.bashrc`              | For bash (optional)             |
-| `.gitconfig`       | `~/.gitconfig`        | `configs/.gitconfig`           | Git user identity, settings     |
-| `settings.json`    | VS Code settings path | `configs/vscode-settings.json` | Optional, if `vscode` installed |
-| `.nvmrc`           | Project root (opt)    | `configs/.nvmrc`               | Node.js version pinning         |
-| `.python-version`  | Project root          | `configs/.python-version`      | Python version pinning (pyenv)  |
-| PowerShell Profile | `$PROFILE`            | `configs/aliases.ps1`          | Auto-injected aliases           |
+| `.zshrc`           | `~/.zshrc`            | `dotfiles/dot_zshrc`               | Used by zsh login shell         |
+| `.gitconfig`       | `~/.gitconfig`        | `dotfiles/dot_gitconfig`           | Git user identity, settings     |
+| `settings.json`    | VS Code settings path | `dotfiles/dot_config/Code/User/settings.json` | Optional, if `vscode` installed |
+| `aliases.sh`       | `~/aliases.sh`        | `dotfiles/aliases.sh`          | Common shell aliases            |
+| `aliases.ps1`      | `$PROFILE`            | `dotfiles/aliases.ps1`         | PowerShell aliases              |
 
 ---
 
@@ -39,12 +37,12 @@ Install and manage custom configuration files for shells, git, editors, and othe
 ## 🧪 Smoke Test
 
 ```bash
-diff ~/.zshrc configs/.zshrc
-diff ~/.gitconfig configs/.gitconfig
+diff ~/.zshrc dotfiles/dot_zshrc
+diff ~/.gitconfig dotfiles/dot_gitconfig
 ```
 
 ```powershell
-Compare-Object (Get-Content $PROFILE) (Get-Content configs/aliases.ps1)
+Compare-Object (Get-Content $PROFILE) (Get-Content dotfiles/aliases.ps1)
 ```
 
 Expected: Files match or show successful linking/copying.

--- a/docs/modules/git.md
+++ b/docs/modules/git.md
@@ -20,7 +20,7 @@ Install and configure Git for version control on all supported platforms.
 
 | File         | Target Path    | Managed By           |
 | ------------ | -------------- | -------------------- |
-| `.gitconfig` | `~/.gitconfig` | `configs/.gitconfig` |
+| `.gitconfig` | `~/.gitconfig` | `dotfiles/dot_gitconfig` |
 
 **Merged via**: Upsert logic that preserves user-defined values but injects defaults if not present.
 

--- a/docs/modules/powershell.md
+++ b/docs/modules/powershell.md
@@ -21,7 +21,7 @@ Configure PowerShell as the default shell environment on Windows (and optionally
 | File                               | Target Path                    | Managed By            |
 | ---------------------------------- | ------------------------------ | --------------------- |
 | `Microsoft.PowerShell_profile.ps1` | `$PROFILE` (platform-specific) | `scripts/setup.ps1`   |
-| Aliases & Prompt                   | Defined in profile script      | `configs/aliases.ps1` |
+| Aliases & Prompt                   | Defined in profile script      | `dotfiles/aliases.ps1` |
 
 **Behavior:**
 

--- a/docs/modules/vscode.md
+++ b/docs/modules/vscode.md
@@ -20,8 +20,8 @@ Install Visual Studio Code and apply user configuration (extensions, settings) a
 
 | File                  | Target Path                                                                                          | Managed By                     |
 | --------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------ |
-| `settings.json`       | `~/.config/Code/User/settings.json` (Linux/macOS) <br> `%APPDATA%\Code\User\settings.json` (Windows) | `configs/vscode-settings.json` |
-| Extensions List (opt) | `vscode-extensions.txt`                                                                              | `configs/`                     |
+| `settings.json`       | `~/.config/Code/User/settings.json` (Linux/macOS) <br> `%APPDATA%\Code\User\settings.json` (Windows) | `dotfiles/dot_config/Code/User/settings.json` |
+| Extensions List (opt) | `vscode-extensions.txt`                                                                              | `dotfiles/`                     |
 
 **Merge Behavior:**
 

--- a/docs/modules/zsh.md
+++ b/docs/modules/zsh.md
@@ -20,14 +20,14 @@ Install and configure `zsh` as the default login shell on macOS and Linux system
 
 | File        | Target Path     | Managed By       |
 | ----------- | --------------- | ---------------- |
-| `.zshrc`    | `~/.zshrc`      | `configs/.zshrc` |
+| `.zshrc`    | `~/.zshrc`      | `dotfiles/dot_zshrc` |
 | `oh-my-zsh` | `~/.oh-my-zsh`  | Install script   |
 | Theme       | `ZSH_THEME=...` | Set in `.zshrc`  |
 
 **Behavior:**
 
 * Backs up existing `.zshrc` if present
-* Symlinks `configs/.zshrc` into `~`
+* Applies `dotfiles/dot_zshrc` with `chezmoi`
 * Installs `oh-my-zsh` from GitHub if not present
 
 ---

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -85,7 +85,7 @@ This logic is embedded within a single `bootstrap` file using multiline heredoc-
 2. **Determine tools to install**
 3. **Check for existing installs**
 4. **Install only what’s missing**
-5. **Link/patch dotfiles into shell envs**
+5. **Apply dotfiles via `chezmoi`**
 6. **Log output and errors to `logs/`**
 7. **Run validation smoke test**
 
@@ -95,11 +95,11 @@ This logic is embedded within a single `bootstrap` file using multiline heredoc-
 
 | Component     | Setup Path                 | Config Source            |
 | ------------- | -------------------------- | ------------------------ |
-| Shell         | `.bashrc` / `.zshrc`       | `configs/`, `dotfiles/`  |
-| Git           | `.gitconfig`               | `configs/`               |
+| Shell         | `.bashrc` / `.zshrc`       | `dotfiles/`          |
+| Git           | `.gitconfig`               | `dotfiles/`          |
 | Python        | `pyenv`, `.python-version` | `configs/dev_env.yml`    |
 | Node.js       | `nvm`, `.nvmrc`            | `configs/dev_env.yml`    |
-| Editor        | VS Code (`settings.json`)  | `configs/` or downloaded |
+| Editor        | VS Code (`settings.json`)  | `dotfiles/`          |
 | Secrets (opt) | `1password` CLI            | Environment + `op run`   |
 
 ---

--- a/dotfiles/aliases.ps1
+++ b/dotfiles/aliases.ps1
@@ -1,0 +1,1 @@
+Set-Alias ll Get-ChildItem

--- a/dotfiles/aliases.sh
+++ b/dotfiles/aliases.sh
@@ -1,0 +1,1 @@
+alias ll='ls -la'

--- a/dotfiles/dot_config/Code/User/settings.json
+++ b/dotfiles/dot_config/Code/User/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.fontSize": 14
+}

--- a/dotfiles/dot_gitconfig
+++ b/dotfiles/dot_gitconfig
@@ -1,0 +1,5 @@
+[user]
+  name = Your Name
+  email = your.email@example.com
+[core]
+  editor = code --wait

--- a/dotfiles/dot_zshrc
+++ b/dotfiles/dot_zshrc
@@ -1,0 +1,3 @@
+# Managed by chezmoi
+source ~/aliases.sh
+export EDITOR="code"

--- a/scripts/setup-linux.sh
+++ b/scripts/setup-linux.sh
@@ -7,5 +7,4 @@ else
   echo "🛠️ Running Linux setup (stub)..."
   # Simulate some logic
   echo "Installing tools for Linux..."
-  echo "Applying dotfiles..."
 fi

--- a/tests/linux/smoke-bootstrap.sh
+++ b/tests/linux/smoke-bootstrap.sh
@@ -23,4 +23,13 @@ else
   exit 1
 fi
 
+# Check for chezmoi step
+if grep -q "chezmoi" "$BOOTSTRAP_OUT"; then
+  echo "✅ Chezmoi step detected"
+else
+  echo "❌ Expected chezmoi step not found in output:"
+  cat "$BOOTSTRAP_OUT"
+  exit 1
+fi
+
 rm "$BOOTSTRAP_OUT"

--- a/tests/macos/smoke-bootstrap.sh
+++ b/tests/macos/smoke-bootstrap.sh
@@ -15,7 +15,7 @@ BOOTSTRAP_OUT=$(mktemp)
 }
 
 # Check for expected dispatch message
-if grep -qF "🧪 [dry-run] setup-macos.sh executed" "$BOOTSTRAP_OUT"; then
+if grep -qF "🧪 [dry-run] setup-macos.sh starting" "$BOOTSTRAP_OUT"; then
   echo "✅ Detected macOS dispatch successful"
 else
   echo "❌ Expected setup-macos.sh dispatch not found in output:"
@@ -23,4 +23,14 @@ else
   exit 1
 fi
 
+# Check for chezmoi step
+if grep -q "chezmoi" "$BOOTSTRAP_OUT"; then
+  echo "✅ Chezmoi step detected"
+else
+  echo "❌ Expected chezmoi step not found in output:"
+  cat "$BOOTSTRAP_OUT"
+  exit 1
+fi
+
 rm "$BOOTSTRAP_OUT"
+


### PR DESCRIPTION
## Summary
- apply dotfiles via `chezmoi` during bootstrap
- add `dotfiles/` source tree with sample zsh, git, alias, and VS Code config
- document dotfile management and update smoke tests

## Testing
- `bash tests/linux/smoke-bootstrap.sh`
- `bash tests/macos/smoke-bootstrap.sh` *(fails: Expected setup-macos.sh dispatch not found in output)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b938a0d0832eba8b28814908a50a